### PR TITLE
Create option --with-single

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
     brew tap optimizers/cutest
     brew tap homebrew/versions   # If you want Matlab support.
-    brew install cutest --HEAD [--with-matlab]
+    brew install cutest --HEAD [--with-matlab] [--with-single]
     brew install mastsif --HEAD  # If you want the whole SIF collection.
     for f in "archdefs" "mastsif" "sifdecode" "cutest"; do \
       echo ". $(brew --prefix $f)/$f.bashrc" >> ~/.bashrc; \
@@ -41,9 +41,11 @@ If you will require Matlab support in CUTEst, you also need to tap [homebrew/ver
 
 Now we can install CUTEst and, at your option, the entire SIF collection:
 
-    brew install cutest --HEAD [--with-matlab]
+    brew install cutest --HEAD [--with-matlab] [--with-single]
     brew install mastsif --HEAD  # If you want the whole SIF collection.
 
+The option `--with-single` will compile the single precision library
+additionally.
 The last thing to do is to add all the requisite environment variables to our `~/.bashrc`. Each package provides a mini `bashrc` that contains the relevant definitions and can be sourced. They can all be sourced in one command:
 
     for f in "archdefs" "mastsif" "sifdecode" "cutest"; do \

--- a/cutest.rb
+++ b/cutest.rb
@@ -13,6 +13,7 @@ class Cutest < Formula
   head "http://ccpforge.cse.rl.ac.uk/svn/cutest/cutest/trunk", :using => AnonymousSubversionDownloadStrategy
 
   option "with-matlab", "Compile with Matlab support"
+  option "with-single", "Compile without single support"
 
   depends_on "gsl"
   depends_on "optimizers/cutest/archdefs" => :build
@@ -25,6 +26,8 @@ class Cutest < Formula
   def install
     ENV.deparallelize
     toolset = (build.with? "matlab") ? "1" : "2"
+    single = (build.with? "single") ? "y" : "n"
+    precisions = (build.with? "single") ? ["single", "double"] : ["double"]
 
     if OS.mac?
       machine, key = (MacOS.prefer_64_bit?) ? %w[mac64 13] : %w[mac 12]
@@ -34,7 +37,7 @@ class Cutest < Formula
         2
         #{toolset}
         4
-        nnydy
+        nnyd#{single}
       EOF
     else
       machine = "pc64"
@@ -45,7 +48,7 @@ class Cutest < Formula
         2
         #{toolset}
         4
-        nnydy
+        nnyd#{single}
       EOF
     end
 
@@ -65,7 +68,7 @@ class Cutest < Formula
       noall_load = "-Wl,-no-whole-archive"
       extra = []
     end
-    ["single", "double"].each do |prec|
+    precisions.each do |prec|
       cd "objects/#{machine}.#{arch}.gfo/#{prec}" do
         Dir["*.a"].each do |l|
           lname = File.basename(l, ".a") + "_#{prec}.#{so}"
@@ -88,8 +91,10 @@ class Cutest < Formula
     lib.install_symlink "#{libexec}/objects/#{machine}.#{arch}.gfo/double/libcutest_double.#{so}"
     ln_sf "#{libexec}/objects/#{machine}.#{arch}.gfo/double/libcutest.a", "#{lib}/libcutest_double.a"
     ln_sf "#{libexec}/objects/#{machine}.#{arch}.gfo/double/libcutest_double.#{so}", "#{lib}/libcutest.#{so}"
-    ln_sf "#{libexec}/objects/#{machine}.#{arch}.gfo/single/libcutest.a", "#{lib}/libcutest_single.a"
-    ln_sf "#{libexec}/objects/#{machine}.#{arch}.gfo/single/libcutest_single.#{so}", "#{lib}/libcutest_single.#{so}"
+    if build.with? "single"
+      ln_sf "#{libexec}/objects/#{machine}.#{arch}.gfo/single/libcutest.a", "#{lib}/libcutest_single.a"
+      ln_sf "#{libexec}/objects/#{machine}.#{arch}.gfo/single/libcutest_single.#{so}", "#{lib}/libcutest_single.#{so}"
+    end
 
     s = <<-EOS.undent
       export CUTEST=#{opt_libexec}


### PR DESCRIPTION
This fixes #12, setting the default option to not install single precision libraries, but enabling with the command line option.

This wasn't well tested because I don't know how to test brew packages locally.

Also, I made a branch that for `--without-single` where the single precision is built by default. I chose to PR this because it passes the travis tests for linux.