### PR TITLE
Use HOMEBREW_BUILD_FROM_SOURCE=1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 install:
   - unset DYLD_LIBRARY_PATH
   - if [ `uname` = "Linux" ]; then bash setup_travis_linux.sh; fi
-  - if [ `uname` = "Linux" ]; then export PATH="$HOME/.linuxbrew/bin:$PATH"; fi
+  - if [ `uname` = "Linux" ]; then export PATH="$HOME/.linuxbrew/bin:$PATH"; export HOMEBREW_BUILD_FROM_SOURCE=1; fi
   - brew update
   - if [ `uname` = "Linux" ]; then brew install pkg-config; fi
   - brew update


### PR DESCRIPTION
My travis stopped working for linux, and [this](https://github.com/Linuxbrew/linuxbrew/issues/813) fixed.
Maybe you can try to restart the build on travis before accepting this.