### PR TITLE
Use gsl@1 instead of deprecated versions/gsl1

### DIFF
--- a/cutest.rb
+++ b/cutest.rb
@@ -18,7 +18,7 @@ class Cutest < Formula
   option "with-pgi", "build with Portland Group compilers"
   option "without-single", "Compile without single support"
 
-  depends_on "homebrew/versions/gsl1"
+  depends_on "gsl@1"
   depends_on "optimizers/cutest/archdefs"
   depends_on "optimizers/cutest/sifdecode" => ((build.with? "pgi") ? ["with-pgi"] : [])
 


### PR DESCRIPTION
Homebrew started supporting older versions.