### PR TITLE
adds NETLIB library to homebrew-cutest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
   - if [ `uname` = "Linux" ]; then bash setup_travis_linux.sh; fi
   - if [ `uname` = "Linux" ]; then export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"; fi
   - if [ `uname` = "Linux" ]; then brew install pkg-config; fi
-  - brew tap homebrew/science
-  # Install homebrew/cutest as tap.
+  - brew tap optimizers/cutest
+  # Install homebrew-cutest as tap.
   - mkdir -p $(brew --repo)/Library/Taps/optimizers
   - ln -s $PWD $(brew --repo)/Library/Taps/optimizers/homebrew-cutest
   - chmod 0644 $(brew --repo)/Library/Taps/optimizers/homebrew-cutest/*.rb

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Now we can install CUTEst and, at your option, the entire SIF collection:
 
     brew install cutest [--with-matlab] [--without-single] [--with-pgi]
     brew install mastsif  # If you want the whole SIF collection.
+    brew install maros_mezaros #If you want the Maros-Mezaros collection
+    brew install netlib #If you want the NETLIB LP collection
+
+Both `maros_mezaros` and `netlib` commands only install data files.  
 
 The option `--without-single` will prevent the single precision library from being built.
 The option `--with-pgi` will build CUTEst and SIFDecode with the PGI compilers, which are assumed to be available.

--- a/netlib.rb
+++ b/netlib.rb
@@ -1,0 +1,28 @@
+# CCPForge requires that svn checkouts be done with --username anonymous.
+# This should be available in Homebrew by default in the near future.
+
+class AnonymousSubversionDownloadStrategy < SubversionDownloadStrategy
+  def quiet_safe_system(*args)
+    super(*args + ["--username", "anonymous"])
+  end
+end
+
+class Netlib < Formula
+  desc "Netlib SIF problems"
+  homepage "http://www.cuter.rl.ac.uk/Problems/netlib.shtml"
+  url "ftp://ftp.numerical.rl.ac.uk/pub/cuter/netlib.tar.gz"
+  sha256 "88f9e05db532535a7356cf16d604c7014feccd6e51062910b0c81fd248c41093"
+
+  keg_only "This formula only installs data files"
+
+  def install
+    pkgshare.install Dir["*.SIF"]
+    Pathname.new("#{prefix}/netlib.bashrc").write <<-EOF.undent
+      export NETLIB=#{opt_share}/netlib
+    EOF
+  end
+
+  test do
+    File.exist? pkgshare/"AFIRO.SIF"
+  end
+end

--- a/netlib.rb
+++ b/netlib.rb
@@ -1,5 +1,5 @@
 class Netlib < Formula
-  desc "Netlib SIF problems"
+  desc "All NETLIB SIF problems"
   homepage "http://www.cuter.rl.ac.uk/Problems/netlib.shtml"
   url "ftp://ftp.numerical.rl.ac.uk/pub/cuter/netlib.tar.gz"
   version "1.0"

--- a/netlib.rb
+++ b/netlib.rb
@@ -1,25 +1,13 @@
-# CCPForge requires that svn checkouts be done with --username anonymous.
-# This should be available in Homebrew by default in the near future.
-
-class AnonymousSubversionDownloadStrategy < SubversionDownloadStrategy
-  def quiet_safe_system(*args)
-    super(*args + ["--username", "anonymous"])
-  end
-end
-
 class Netlib < Formula
   desc "Netlib SIF problems"
   homepage "http://www.cuter.rl.ac.uk/Problems/netlib.shtml"
   url "ftp://ftp.numerical.rl.ac.uk/pub/cuter/netlib.tar.gz"
+  version "1.0"
   sha256 "88f9e05db532535a7356cf16d604c7014feccd6e51062910b0c81fd248c41093"
-
-  keg_only "This formula only installs data files"
+  keg_only "this formula only installs data files"
 
   def install
     pkgshare.install Dir["*.SIF"]
-    Pathname.new("#{prefix}/netlib.bashrc").write <<-EOF.undent
-      export NETLIB=#{opt_share}/netlib
-    EOF
   end
 
   test do


### PR DESCRIPTION
This formula only installs data files of NETLIB.

We should add to README the export MASTSIF changing if one wants to use MM or NETLIB library.